### PR TITLE
Removed the stash_metadata() function

### DIFF
--- a/stash-child/header.php
+++ b/stash-child/header.php
@@ -12,7 +12,6 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 	<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
-	<?php stash_metadata(); ?>
 	<?php wp_head(); ?>
 </head>
 


### PR DESCRIPTION
The stash_metadata() function has been deprecated, in favor of external plugin functionality (as it should be). 